### PR TITLE
Add bug fix guide and SQL trigger for quest points calculation

### DIFF
--- a/FIX_GUIDE.md
+++ b/FIX_GUIDE.md
@@ -1,0 +1,101 @@
+# 🐛 BUG FIX: Quest Points = 0
+
+## Vấn đề
+
+User verify quest nhưng không nhận được điểm (totalPoints = 0)
+
+## Nguyên nhân
+
+Trigger database chỉ chạy khi UPDATE, không chạy khi INSERT.
+→ Code INSERT user_quest với status='verified' → Trigger không chạy → Không cộng điểm
+
+## ✅ Cách Fix
+
+### Bước 1: Chạy SQL vào database
+
+**Option 1: Dùng Supabase Dashboard**
+
+1. Vào Supabase Dashboard → SQL Editor
+2. Copy nội dung file `fix_trigger.sql` và paste vào
+3. Click Run
+
+**Option 2: Dùng psql command line**
+
+```bash
+psql -U postgres -d your_database -f fix_trigger.sql
+```
+
+**Option 3: Copy-paste SQL này vào database tool của bạn:**
+
+```sql
+DROP TRIGGER IF EXISTS trg_apply_points_on_verify ON user_quests;
+
+CREATE TRIGGER trg_apply_points_on_verify
+AFTER INSERT OR UPDATE ON user_quests
+FOR EACH ROW
+WHEN (NEW.status = 'verified')
+EXECUTE FUNCTION apply_points_on_verify();
+```
+
+### Bước 2: Verify trigger đã fix
+
+**Option 1: Test tự động**
+Chạy file `test_fix.sql`:
+
+```bash
+psql -U postgres -d your_database -f test_fix.sql
+```
+
+Kết quả mong đợi:
+
+```
+✅ ✅ ✅ SUCCESS! Trigger worked correctly!
+Points increased from 0 to 20 (+20)
+```
+
+**Option 2: Test thủ công**
+Chạy query này để check trigger definition:
+
+```sql
+SELECT pg_get_triggerdef((
+  SELECT oid FROM pg_trigger
+  WHERE tgname = 'trg_apply_points_on_verify'
+));
+```
+
+Kết quả phải có: `AFTER INSERT OR UPDATE` ✅
+
+### Bước 3: Test với API thực tế
+
+1. Login lại để lấy token mới
+2. Verify một quest bất kỳ
+3. Check API `/api/v1/quests/my-stats`
+4. `totalPoints` phải > 0 ✅
+
+## 🎯 Kết quả mong đợi
+
+**Trước khi fix:**
+
+```json
+{
+  "totalPoints": 0, // ❌
+  "completedQuests": 1
+}
+```
+
+**Sau khi fix:**
+
+```json
+{
+  "totalPoints": 20, // ✅
+  "completedQuests": 1
+}
+```
+
+---
+
+**Nếu vẫn gặp vấn đề, kiểm tra:**
+
+- Trigger function có tồn tại không: `SELECT proname FROM pg_proc WHERE proname = 'apply_points_on_verify';`
+- User có tồn tại trong database không
+- JWT token có còn valid không (check expiry time)

--- a/fix_trigger.sql
+++ b/fix_trigger.sql
@@ -1,0 +1,13 @@
+-- Fix trigger để chạy cả INSERT và UPDATE
+-- Bug: Trigger chỉ chạy AFTER UPDATE nên khi INSERT user_quest với status='verified' thì không cộng điểm
+
+DROP TRIGGER IF EXISTS trg_apply_points_on_verify ON user_quests;
+
+CREATE TRIGGER trg_apply_points_on_verify
+AFTER INSERT OR UPDATE ON user_quests
+FOR EACH ROW
+WHEN (NEW.status = 'verified')
+EXECUTE FUNCTION apply_points_on_verify();
+
+-- Verify trigger đã được tạo đúng
+SELECT pg_get_triggerdef((SELECT oid FROM pg_trigger WHERE tgname = 'trg_apply_points_on_verify')); 

--- a/src/app/api/v1/quests/[code]/verify/route.ts
+++ b/src/app/api/v1/quests/[code]/verify/route.ts
@@ -116,6 +116,9 @@ async function verifyQuestHandler(
     );
   } catch (error) {
     console.error('Quest verification error:', error);
+    console.error('Error type:', error instanceof Error);
+    console.error('Error message:', error instanceof Error ? error.message : String(error));
+    console.error('Error stack:', error instanceof Error ? error.stack : 'No stack');
 
     // Handle known errors
     if (error instanceof Error) {
@@ -153,7 +156,8 @@ async function verifyQuestHandler(
             {
               success: false,
               error: 'VERIFICATION_FAILED',
-              message: 'Quest verification failed. Please check your proof.',
+              message:
+                'Quest verification failed. Please check your proof format and ensure it matches the quest type requirements.',
             },
             { status: 400 }
           );
@@ -167,14 +171,24 @@ async function verifyQuestHandler(
         case 'INTERNAL_ERROR':
         default:
           return NextResponse.json(
-            { success: false, error: 'INTERNAL_ERROR', message: 'Internal server error' },
+            {
+              success: false,
+              error: 'INTERNAL_ERROR',
+              message: 'Internal server error',
+              details: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+            },
             { status: 500 }
           );
       }
     }
 
     return NextResponse.json(
-      { success: false, error: 'INTERNAL_ERROR', message: 'Internal server error' },
+      {
+        success: false,
+        error: 'INTERNAL_ERROR',
+        message: 'Internal server error',
+        details: process.env.NODE_ENV === 'development' ? String(error) : undefined,
+      },
       { status: 500 }
     );
   }

--- a/src/app/api/v1/referral/my-code/route.ts
+++ b/src/app/api/v1/referral/my-code/route.ts
@@ -114,6 +114,15 @@ async function getMyCodeHandler(req: AuthenticatedRequest) {
     const totalReferralPoints =
       referralRewards?.reduce((sum, reward) => sum + reward.points_earned, 0) || 0;
 
+    // Get user's total points from quests
+    const { data: userPoints } = await supabase
+      .from('user_points')
+      .select('total_points')
+      .eq('user_id', user.userId)
+      .single();
+
+    const totalPoints = userPoints?.total_points || 0;
+
     // Get list of referred users (recent 10)
     const { data: referredUsers } = await supabase
       .from('users')
@@ -136,6 +145,7 @@ async function getMyCodeHandler(req: AuthenticatedRequest) {
         stats: {
           totalReferrals: totalReferrals || 0,
           totalReferralPoints,
+          totalPoints, // Tổng điểm từ quest
         },
         recentReferrals: referredUsers || [],
       },

--- a/src/queries/useQuestQueries.ts
+++ b/src/queries/useQuestQueries.ts
@@ -86,9 +86,9 @@ export const useVerifyQuest = () => {
       const response = await Service.quest.verifyQuest(questCode, request, idempotencyKey);
       return response;
     },
-    onSuccess: (data) => {
-      if (data.success && data.data) {
-        toast.success(`Quest verified! You earned ${data.data.result.awardedPoints} points!`);
+    onSuccess: (data: any) => {
+      if (data.success && data.result) {
+        toast.success(`Quest verified! You earned ${data.result.awardedPoints} points!`);
 
         // Invalidate and refetch related queries
         queryClient.invalidateQueries({ queryKey: ['quests'] });

--- a/src/queries/useReferralQueries.ts
+++ b/src/queries/useReferralQueries.ts
@@ -88,6 +88,7 @@ export const useGetReferralStats = () => {
           currentTier: calculateTier(response.data.stats?.totalReferralPoints || 0),
           totalReferrals: response.data.stats?.totalReferrals || 0,
           totalReferralPoints: response.data.stats?.totalReferralPoints || 0,
+          totalPoints: response.data.stats?.totalPoints || 0, // Điểm từ quest
           referralLink: generateReferralLink(response.data.myInviteCode),
           referredBy: response.data.referredBy,
           recentReferrals: response.data.recentReferrals || [],

--- a/src/screens/Referral/components/ReferralStats.tsx
+++ b/src/screens/Referral/components/ReferralStats.tsx
@@ -7,12 +7,14 @@ import Image from 'next/image';
 interface ReferralStatsProps {
   totalReferrals: number;
   totalReferralPoints: number;
+  totalPoints: number; // Điểm từ quest
   tier: number;
 }
 
 export default function ReferralStats({
   totalReferrals,
   totalReferralPoints,
+  totalPoints,
   tier,
 }: ReferralStatsProps) {
   return (
@@ -32,11 +34,11 @@ export default function ReferralStats({
             <div className="w-full text-center">
               <div className="flex items-center justify-center gap-0">
                 <div className="text-2xl font-bold text-gray-900">
-                  {formatNumberShort(totalReferralPoints)}
+                  {formatNumberShort(totalPoints)}
                 </div>
                 <Image src={'/point.png'} height={24} width={24} alt="points" />
               </div>
-              <div className="text-sm text-content">Total Referee Filled Volume</div>
+              <div className="text-sm text-content">Total Points from Quests</div>
             </div>
           </div>
         </div>

--- a/src/screens/Referral/index.tsx
+++ b/src/screens/Referral/index.tsx
@@ -53,6 +53,7 @@ export default function ReferralScreen() {
           <ReferralStats
             totalReferrals={data?.totalReferrals || 0}
             totalReferralPoints={data?.totalReferralPoints || 0}
+            totalPoints={data?.totalPoints || 0}
             tier={data?.currentTier || 0}
           />
           <RewardHistory />

--- a/src/server/db/migrations/quest_system_migration.sql
+++ b/src/server/db/migrations/quest_system_migration.sql
@@ -148,7 +148,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trg_apply_points_on_verify
-AFTER UPDATE ON user_quests
+AFTER INSERT OR UPDATE ON user_quests
 FOR EACH ROW
 WHEN (NEW.status = 'verified')
 EXECUTE FUNCTION apply_points_on_verify();

--- a/src/server/service/quest.service.ts
+++ b/src/server/service/quest.service.ts
@@ -122,7 +122,7 @@ export class QuestService {
     }
 
     if (!data) {
-      console.log(`Quest with code "${code}" not found in database`);
+      console.log(`Quest with code "${code}" not found`);
       return null;
     }
 
@@ -176,9 +176,13 @@ export class QuestService {
    * Create user quest record
    */
   private async createUserQuest(userQuest: Omit<UserQuest, 'id'>): Promise<string> {
+    // Generate UUID manually to avoid Supabase default value issues
+    const userQuestId = crypto.randomUUID();
+
     const { data, error } = await supabase
       .from('user_quests')
       .insert({
+        id: userQuestId,
         user_id: userQuest.userId,
         quest_id: userQuest.questId,
         status: userQuest.status,

--- a/test_fix.sql
+++ b/test_fix.sql
@@ -1,0 +1,90 @@
+-- Test script: Verify trigger fix hoạt động đúng
+-- Chạy script này SAU KHI đã apply fix_trigger.sql
+
+-- 1. Check trigger definition
+SELECT '=== CHECKING TRIGGER ===' as status;
+SELECT pg_get_triggerdef((
+  SELECT oid FROM pg_trigger 
+  WHERE tgname = 'trg_apply_points_on_verify'
+));
+-- Phải có "AFTER INSERT OR UPDATE" ✅
+
+-- 2. Test với user và quest thực tế
+DO $$
+DECLARE
+  test_user_id UUID;
+  test_quest_id UUID;
+  test_quest_points INT;
+  user_quest_id UUID;
+  points_before BIGINT;
+  points_after BIGINT;
+BEGIN
+  -- Lấy user đầu tiên trong database
+  SELECT id INTO test_user_id FROM users LIMIT 1;
+  
+  -- Lấy active quest đầu tiên
+  SELECT id, points INTO test_quest_id, test_quest_points 
+  FROM quests WHERE status = 'active' LIMIT 1;
+
+  RAISE NOTICE '=== TEST SETUP ===';
+  RAISE NOTICE 'User ID: %', test_user_id;
+  RAISE NOTICE 'Quest ID: %', test_quest_id;
+  RAISE NOTICE 'Quest Points: %', test_quest_points;
+
+  -- Check điểm hiện tại
+  SELECT COALESCE(total_points, 0) INTO points_before 
+  FROM user_points WHERE user_id = test_user_id;
+  
+  RAISE NOTICE 'Points BEFORE: %', points_before;
+
+  -- Test: INSERT user_quest với status = verified
+  user_quest_id := gen_random_uuid();
+  
+  INSERT INTO user_quests (
+    id, user_id, quest_id, status,
+    proof_payload, submitted_at, verified_at
+  ) VALUES (
+    user_quest_id, test_user_id, test_quest_id, 'verified',
+    '{"test": true}'::jsonb, now(), now()
+  );
+
+  -- Wait một chút để trigger chạy
+  PERFORM pg_sleep(0.1);
+
+  -- Check điểm sau khi insert
+  SELECT COALESCE(total_points, 0) INTO points_after 
+  FROM user_points WHERE user_id = test_user_id;
+
+  RAISE NOTICE 'Points AFTER: %', points_after;
+  RAISE NOTICE '';
+
+  -- Verify kết quả
+  IF points_after = points_before + test_quest_points THEN
+    RAISE NOTICE '✅ ✅ ✅ SUCCESS! Trigger worked correctly!';
+    RAISE NOTICE 'Points increased from % to % (+%)', points_before, points_after, test_quest_points;
+  ELSE
+    RAISE NOTICE '❌ ❌ ❌ FAILED! Trigger did not work!';
+    RAISE NOTICE 'Expected points: %, Actual points: %', points_before + test_quest_points, points_after;
+  END IF;
+
+  RAISE NOTICE '';
+  RAISE NOTICE '=== CLEANUP ===';
+  
+  -- Cleanup: Xóa test data
+  DELETE FROM user_quests WHERE id = user_quest_id;
+  
+  -- Restore original points
+  IF points_before = 0 THEN
+    DELETE FROM user_points WHERE user_id = test_user_id;
+  ELSE
+    UPDATE user_points 
+    SET total_points = points_before 
+    WHERE user_id = test_user_id;
+  END IF;
+  
+  RAISE NOTICE 'Test data cleaned up';
+
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE NOTICE 'Error occurred: %', SQLERRM;
+END $$; 


### PR DESCRIPTION
- Introduced FIX_GUIDE.md to document the bug related to quest points not being awarded correctly due to trigger execution issues on INSERT.
- Added fix_trigger.sql to create a trigger that executes on both INSERT and UPDATE for user_quests.
- Included test_fix.sql to verify the functionality of the new trigger.
- Updated relevant API routes and components to ensure total quest points are correctly fetched and displayed in the referral stats.